### PR TITLE
Thinサーバを使うように修正しました

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source :rubygems
 gem 'rack'
 gem 'sinatra'
 gem 'rspec'
+gem 'thin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,9 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    daemons (1.1.4)
     diff-lcs (1.1.3)
+    eventmachine (0.12.10)
     rack (1.3.5)
     rack-protection (1.1.4)
       rack
@@ -17,6 +19,10 @@ GEM
       rack (~> 1.3, >= 1.3.4)
       rack-protection (~> 1.1, >= 1.1.2)
       tilt (~> 1.3, >= 1.3.3)
+    thin (1.2.11)
+      daemons (>= 1.0.9)
+      eventmachine (>= 0.12.6)
+      rack (>= 1.0.0)
     tilt (1.3.3)
 
 PLATFORMS
@@ -26,3 +32,4 @@ DEPENDENCIES
   rack
   rspec
   sinatra
+  thin

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec rackup config.ru -p $PORT
+web: bundle exec thin start -p $PORT


### PR DESCRIPTION
cedarスタックにてデフォルトのWEBrickの代わりにThinサーバを使うようにしました。
