### PR TITLE
exclude free riders

### DIFF
--- a/amazon-auth-proxy.cgi
+++ b/amazon-auth-proxy.cgi
@@ -48,22 +48,23 @@ module HMAC
 end
 
 def paapi( conf, params )
+	raise ArgumentError::new( 'No AssociateTag' ) unless conf['default_aid']
+
 	xslt = false
 	qs = [].tap {|q|
 		params.each do |key, values|
 			if key =~ /^(AWSAccessKeyId|SubscriptionId)$/
 				q << "#{u key}=#{u conf['access_key']}"
+			elsif key == 'AssociateTag'
+				# ignore this key and insert after
 			elsif key == 'Timestamp'
-				# ignore this key
+				# ignore this key and insert after
 			else
 				q << "#{u key}=#{u values[0]}"
 				xslt = true if key == 'Style'
 			end
 		end
-		unless params.keys.include?( 'AssociateTag' ) then
-			raise ArgumentError::new( 'No AssociateTag' ) unless conf['default_aid']
-			q << "AssociateTag=#{u conf['default_aid']}"
-		end
+		q << "AssociateTag=#{u conf['default_aid']}"
 		q << "Timestamp=#{u DateTime.now.new_offset.strftime('%Y-%m-%dT%XZ') }"
 	}.sort
 

--- a/spec/amazon-auth-proxy.cgi_spec.rb
+++ b/spec/amazon-auth-proxy.cgi_spec.rb
@@ -49,9 +49,9 @@ describe 'paapi' do
 			expect(paapi( @conf, @req )[1]).to starts_with 'http://xml-jp.amznxslt.com/onca/xml?AssociateTag=cshs-22&ItemPage=1&Keywords=Amazon&Operation=ItemSearch&ResponseGroup=Small&SearchIndex=Books&Service=AWSECommerceService&Style=dummy&SubscriptionId=SAMPLE_ACCESS_KEY&Timestamp='
 		end
 
-		it 'AssociateTagを指定するとそれを使う' do
+		it 'AssociateTagを指定してあっても上書きする' do
 			@req['AssociateTag'] = ['sample-22']
-			expect(paapi( @conf, @req )[1]).to starts_with 'http://webservices.amazon.co.jp/onca/xml?AssociateTag=sample-22&ItemPage=1&Keywords=Amazon&Operation=ItemSearch&ResponseGroup=Small&SearchIndex=Books&Service=AWSECommerceService&SubscriptionId=SAMPLE_ACCESS_KEY&Timestamp='
+			expect(paapi( @conf, @req )[1]).to starts_with 'http://webservices.amazon.co.jp/onca/xml?AssociateTag=cshs-22&ItemPage=1&Keywords=Amazon&Operation=ItemSearch&ResponseGroup=Small&SearchIndex=Books&Service=AWSECommerceService&SubscriptionId=SAMPLE_ACCESS_KEY&Timestamp='
 		end
 	end
 


### PR DESCRIPTION
PA-APIの運用方針変更にともない、proxyを運用していないフリーライダーを除外する必要がある(proxy運営者の収益を確保するため)。このためにクエリに`AssociateTag`が指定してあっても運営者のもので上書きするように変更する。 See:  tdiary/rpaproxy-sinatra#42